### PR TITLE
[SITIONIX-95] - Align outbox publisher contract with forge-common

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -55,6 +55,16 @@ jobs:
                 <username>${{ github.actor }}</username>
                 <password>${AUTH_TOKEN}</password>
               </server>
+              <server>
+                <id>github-forge-security</id>
+                <username>${{ github.actor }}</username>
+                <password>${AUTH_TOKEN}</password>
+              </server>
+              <server>
+                <id>github-forge-common</id>
+                <username>${{ github.actor }}</username>
+                <password>${AUTH_TOKEN}</password>
+              </server>
             </servers>
           </settings>" > ~/.m2/settings.xml
 

--- a/pipe/pipe-producer-notification-v1/src/main/java/com/sitionix/athssox/pipe/producer/NotificationPublisherV1.java
+++ b/pipe/pipe-producer-notification-v1/src/main/java/com/sitionix/athssox/pipe/producer/NotificationPublisherV1.java
@@ -5,7 +5,7 @@ import com.app_afesox.ntfssox.events.notifications.kafka.NotificationsV1Producer
 import com.sitionix.athssox.domain.model.outbox.payload.EmailVerifyPayload;
 import com.sitionix.athssox.pipe.producer.mapper.NotificationEventMapper;
 import com.sitionix.forge.outbox.core.model.Event;
-import com.sitionix.forge.outbox.core.port.ForgeTypedOutboxEventPublisher;
+import com.sitionix.forge.outbox.core.port.ForgeOutboxEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -13,19 +13,19 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class NotificationPublisherV1 extends ForgeTypedOutboxEventPublisher<EmailVerifyPayload> {
+public class NotificationPublisherV1 implements ForgeOutboxEventPublisher<EmailVerifyPayload> {
 
     private final NotificationsV1Producer producer;
 
     private final NotificationEventMapper mapper;
 
     @Override
-    protected Class<EmailVerifyPayload> payloadClass() {
+    public Class<EmailVerifyPayload> payloadClass() {
         return EmailVerifyPayload.class;
     }
 
     @Override
-    protected void publish(final Event<EmailVerifyPayload> event) {
+    public void publish(final Event<EmailVerifyPayload> event) {
         log.info("Publish notification event");
         final String key = event.getIdempotencyId().toString();
         final NotificationEnvelope envelope = this.mapper.asEnvelope(event);

--- a/pipe/pipe-producer-notification-v1/src/main/java/com/sitionix/athssox/pipe/producer/NotificationPublisherV1.java
+++ b/pipe/pipe-producer-notification-v1/src/main/java/com/sitionix/athssox/pipe/producer/NotificationPublisherV1.java
@@ -3,10 +3,9 @@ package com.sitionix.athssox.pipe.producer;
 import com.app_afesox.ntfssox.events.notifications.NotificationEnvelope;
 import com.app_afesox.ntfssox.events.notifications.kafka.NotificationsV1Producer;
 import com.sitionix.athssox.domain.model.outbox.payload.EmailVerifyPayload;
-import com.sitionix.athssox.domain.model.outbox.payload.NotificationTemplate;
 import com.sitionix.athssox.pipe.producer.mapper.NotificationEventMapper;
 import com.sitionix.forge.outbox.core.model.Event;
-import com.sitionix.forge.outbox.core.port.ForgeOutboxEventPublisher;
+import com.sitionix.forge.outbox.core.port.ForgeTypedOutboxEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -14,24 +13,19 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class NotificationPublisherV1 implements ForgeOutboxEventPublisher<EmailVerifyPayload> {
+public class NotificationPublisherV1 extends ForgeTypedOutboxEventPublisher<EmailVerifyPayload> {
 
     private final NotificationsV1Producer producer;
 
     private final NotificationEventMapper mapper;
 
     @Override
-    public String eventType() {
-        return NotificationTemplate.EMAIL_VERIFY.getDescription();
-    }
-
-    @Override
-    public Class<EmailVerifyPayload> payloadType() {
+    protected Class<EmailVerifyPayload> payloadClass() {
         return EmailVerifyPayload.class;
     }
 
     @Override
-    public void publish(final Event<EmailVerifyPayload> event) {
+    protected void publish(final Event<EmailVerifyPayload> event) {
         log.info("Publish notification event");
         final String key = event.getIdempotencyId().toString();
         final NotificationEnvelope envelope = this.mapper.asEnvelope(event);

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <spring.version>3.3.4</spring.version>
         <forgeit.version>0.0.35</forgeit.version>
         <forge.security.version>0.0.4</forge.security.version>
-        <forge.common.version>0.0.1</forge.common.version>
+        <forge.common.version>0.0.2</forge.common.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
## Summary
- align NotificationPublisherV1 with new forge-common typed publisher API via payloadClass override
- remove explicit constructor super payload wiring in publisher
- update forge-common dependency version to 0.0.2

## Validation
- mvn -q -f /Users/vladvinskevitch/Documents/Java/sitionix/authorisationservice-sox/pom.xml -pl pipe/pipe-producer-notification-v1,domain -am test
