### PR TITLE
[SITIONIX-95] - Align auth service with forge outbox 0.0.5

### DIFF
--- a/pipe/pipe-producer-notification-v1/src/main/java/com/sitionix/athssox/pipe/producer/NotificationPublisherV1.java
+++ b/pipe/pipe-producer-notification-v1/src/main/java/com/sitionix/athssox/pipe/producer/NotificationPublisherV1.java
@@ -3,7 +3,6 @@ package com.sitionix.athssox.pipe.producer;
 import com.app_afesox.ntfssox.events.notifications.NotificationEnvelope;
 import com.app_afesox.ntfssox.events.notifications.kafka.NotificationsV1Producer;
 import com.sitionix.athssox.domain.model.outbox.payload.EmailVerifyPayload;
-import com.sitionix.athssox.domain.model.outbox.payload.NotificationTemplate;
 import com.sitionix.athssox.pipe.producer.mapper.NotificationEventMapper;
 import com.sitionix.forge.outbox.core.model.Event;
 import com.sitionix.forge.outbox.core.port.ForgeOutboxEventPublisher;
@@ -21,12 +20,7 @@ public class NotificationPublisherV1 implements ForgeOutboxEventPublisher<EmailV
     private final NotificationEventMapper mapper;
 
     @Override
-    public String eventType() {
-        return NotificationTemplate.EMAIL_VERIFY.getDescription();
-    }
-
-    @Override
-    public Class<EmailVerifyPayload> payloadType() {
+    public Class<EmailVerifyPayload> payloadClass() {
         return EmailVerifyPayload.class;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <spring.version>3.3.4</spring.version>
         <forgeit.version>0.0.35</forgeit.version>
         <forge.security.version>0.0.4</forge.security.version>
-        <forge.common.version>0.0.5</forge.common.version>
+        <forge.common.version>0.0.6</forge.common.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <spring.version>3.3.4</spring.version>
         <forgeit.version>0.0.35</forgeit.version>
         <forge.security.version>0.0.4</forge.security.version>
-        <forge.common.version>0.0.1</forge.common.version>
+        <forge.common.version>0.0.5</forge.common.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
## Summary
- bump forge.common.version to 0.0.5
- adapt NotificationPublisherV1 to new ForgeOutboxEventPublisher contract
- remove obsolete eventType/payloadType methods and use payloadClass()

## Verification
- mvn clean install -DskipITs (authorisationservice-sox)
