### PR TITLE
[SITIONIX-101] - target auth db tunnel at VM loopback

### DIFF
--- a/.github/actions/db-migrate-run/action.yml
+++ b/.github/actions/db-migrate-run/action.yml
@@ -112,6 +112,6 @@ runs:
           fi
         fi
 
-        "${flyway_docker[@]}" validate
         "${flyway_docker[@]}" migrate
+        "${flyway_docker[@]}" validate
         "${flyway_docker[@]}" info

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Current `db-model.yaml` mapping for `dev` requires:
   - `DEPLOY_VM_HOST`
   - `DEPLOY_VM_USER`
   - `DEPLOY_VM_SSH_PRIVATE_KEY`
+  - remote tunnel target `127.0.0.1:5432` on the VM host
 
 
 ## Dev key generation (PEM)

--- a/db-migration/db-model.yaml
+++ b/db-migration/db-model.yaml
@@ -7,5 +7,5 @@ database:
       password_secret_name: AUTHS_SOX_DB_PASSWORD
       tunnel:
         local_port: 15432
-        remote_host: postgres
+        remote_host: 127.0.0.1
         remote_port: 5432


### PR DESCRIPTION
## Summary
- target the auth db SSH tunnel at VM loopback instead of the Docker-only postgres alias
- keep the local Flyway URL on 127.0.0.1:15432
- document the VM loopback tunnel target in the migration README