### PR TITLE
[SITIONIX-101] - split auth comment workflows and add health checks

### DIFF
--- a/.github/actions/auth-dev-deploy-run/action.yml
+++ b/.github/actions/auth-dev-deploy-run/action.yml
@@ -116,6 +116,8 @@ runs:
         SITIONIX_KEYS_DIR=/opt/sitionix/runtime/authorisationservice-sox/shared/keys
         SITIONIX_JWT_PRIVATE_KEY_PATH=/opt/sitionix/runtime/authorisationservice-sox/shared/keys/jwt-private.pem
         SITIONIX_JWT_PUBLIC_KEY_PATH=/opt/sitionix/runtime/authorisationservice-sox/shared/keys/jwt-public.pem
+        SITIONIX_LOCAL_READINESS_URL=http://127.0.0.1:9090/authsox/actuator/health/readiness
+        SITIONIX_LOCAL_HEALTH_URL=http://127.0.0.1:9090/authsox/actuator/health
         SITIONIX_LOCAL_JWKS_URL=http://127.0.0.1:9090/authsox/.well-known/jwks.json
         SITIONIX_LOCAL_JWKS_ALIAS_URL=http://127.0.0.1:9090/authsox/oauth2/v1/keys
         SITIONIX_DB_URL=jdbc:postgresql://postgres:5432/auths_sox
@@ -219,4 +221,4 @@ runs:
       shell: bash
       env:
         SITIONIX_RELEASE_ID: ${{ steps.release.outputs.release_id }}
-      run: deploy/auth/ci/verify-private-deploy.sh
+      run: bash deploy/auth/ci/verify-private-deploy.sh

--- a/.github/workflows/db-migrate-on-command.yml
+++ b/.github/workflows/db-migrate-on-command.yml
@@ -1,0 +1,117 @@
+name: DB Migrate On Command
+
+on:
+  repository_dispatch:
+    types:
+      - db-migrate-command
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.client_payload.environmentId }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.checkoutRef }}
+          fetch-depth: 0
+
+      - name: Post start comment
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.client_payload.prNumber }}
+          TARGET_SUMMARY: ${{ github.event.client_payload.targetSummary }}
+          PR_HEAD_REF: ${{ github.event.client_payload.prHeadRef }}
+        with:
+          script: |
+            const pullNumber = Number(process.env.PR_NUMBER);
+            const workflowRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = [
+              "---",
+              "### DB migration started",
+              "",
+              `- Target: ${process.env.TARGET_SUMMARY}`,
+              `- Branch: ${process.env.PR_HEAD_REF}`,
+              `- Workflow: ${workflowRunUrl}`,
+              "---",
+            ].join("\n");
+
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+              body,
+              event: "COMMENT",
+            });
+
+      - name: Execute migration
+        uses: ./.github/actions/db-migrate-run
+        with:
+          environment_id: ${{ github.event.client_payload.environmentId }}
+          database_name: ${{ github.event.client_payload.databaseName }}
+        env:
+          FLYWAY_URL: ${{ github.event.client_payload.databaseUrl }}
+          FLYWAY_USERNAME: ${{ github.event.client_payload.databaseUsername }}
+          FLYWAY_PASSWORD: ${{ secrets[github.event.client_payload.databasePasswordSecretName] }}
+          DEPLOY_VM_HOST: ${{ secrets.DEPLOY_VM_HOST }}
+          DEPLOY_VM_USER: ${{ secrets.DEPLOY_VM_USER }}
+          DEPLOY_VM_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_VM_SSH_PRIVATE_KEY }}
+          SSH_TUNNEL_LOCAL_PORT: ${{ github.event.client_payload.tunnelLocalPort }}
+          SSH_TUNNEL_REMOTE_HOST: ${{ github.event.client_payload.tunnelRemoteHost }}
+          SSH_TUNNEL_REMOTE_PORT: ${{ github.event.client_payload.tunnelRemotePort }}
+
+      - name: Post success comment
+        if: success()
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.client_payload.prNumber }}
+          TARGET_SUMMARY: ${{ github.event.client_payload.targetSummary }}
+          ENVIRONMENT_ID: ${{ github.event.client_payload.environmentId }}
+        with:
+          script: |
+            const pullNumber = Number(process.env.PR_NUMBER);
+            const body = [
+              "---",
+              "### DB migration succeeded",
+              "",
+              `- Target: ${process.env.TARGET_SUMMARY}`,
+              `- GitHub Environment: ${process.env.ENVIRONMENT_ID}`,
+              "---",
+            ].join("\n");
+
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+              body,
+              event: "COMMENT",
+            });
+
+      - name: Post failure comment
+        if: failure()
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.client_payload.prNumber }}
+          TARGET_SUMMARY: ${{ github.event.client_payload.targetSummary }}
+        with:
+          script: |
+            const pullNumber = Number(process.env.PR_NUMBER);
+            const workflowRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = [
+              "---",
+              "### DB migration failed",
+              "",
+              `- Target: ${process.env.TARGET_SUMMARY}`,
+              `- Workflow: ${workflowRunUrl}`,
+              "---",
+            ].join("\n");
+
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+              body,
+              event: "COMMENT",
+            });

--- a/.github/workflows/deploy-on-comment.yml
+++ b/.github/workflows/deploy-on-comment.yml
@@ -1,4 +1,4 @@
-name: Deploy On Comment
+name: Deploy Comment Router
 
 on:
   issue_comment:
@@ -158,235 +158,82 @@ jobs:
           comment_body: ${{ github.event.comment.body }}
           is_pull_request: "true"
 
-  migrate:
+  dispatch-db-migrate:
     needs:
       - prepare
       - resolve-db
     if: needs.resolve-db.outputs.enabled == 'true'
     runs-on: ubuntu-latest
-    environment: ${{ needs.resolve-db.outputs.environment_id }}
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.prepare.outputs.checkout_ref }}
-          fetch-depth: 0
-
-      - name: Post start comment
+      - name: Dispatch DB migrate workflow
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
           TARGET_SUMMARY: ${{ needs.resolve-db.outputs.summary }}
           PR_HEAD_REF: ${{ needs.prepare.outputs.pr_head_ref }}
-        with:
-          script: |
-            const pullNumber = Number(process.env.PR_NUMBER);
-            const workflowRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const body = [
-              "---",
-              "### DB migration started",
-              "",
-              `- Target: ${process.env.TARGET_SUMMARY}`,
-              `- Branch: ${process.env.PR_HEAD_REF}`,
-              `- Workflow: ${workflowRunUrl}`,
-              "---",
-            ].join("\n");
-
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullNumber,
-              body,
-              event: "COMMENT",
-            });
-
-      - name: Execute migration
-        uses: ./.github/actions/db-migrate-run
-        with:
-          environment_id: ${{ needs.resolve-db.outputs.environment_id }}
-          database_name: ${{ needs.resolve-db.outputs.database_name }}
-        env:
-          FLYWAY_URL: ${{ needs.resolve-db.outputs.database_url }}
-          FLYWAY_USERNAME: ${{ needs.resolve-db.outputs.database_username }}
-          FLYWAY_PASSWORD: ${{ secrets[needs.resolve-db.outputs.database_password_secret_name] }}
-          DEPLOY_VM_HOST: ${{ secrets.DEPLOY_VM_HOST }}
-          DEPLOY_VM_USER: ${{ secrets.DEPLOY_VM_USER }}
-          DEPLOY_VM_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_VM_SSH_PRIVATE_KEY }}
-          SSH_TUNNEL_LOCAL_PORT: ${{ needs.resolve-db.outputs.tunnel_local_port }}
-          SSH_TUNNEL_REMOTE_HOST: ${{ needs.resolve-db.outputs.tunnel_remote_host }}
-          SSH_TUNNEL_REMOTE_PORT: ${{ needs.resolve-db.outputs.tunnel_remote_port }}
-
-      - name: Post success comment
-        if: success()
-        uses: actions/github-script@v7
-        env:
-          PR_NUMBER: ${{ github.event.issue.number }}
-          TARGET_SUMMARY: ${{ needs.resolve-db.outputs.summary }}
+          CHECKOUT_REF: ${{ needs.prepare.outputs.checkout_ref }}
           ENVIRONMENT_ID: ${{ needs.resolve-db.outputs.environment_id }}
+          DATABASE_NAME: ${{ needs.resolve-db.outputs.database_name }}
+          DATABASE_URL: ${{ needs.resolve-db.outputs.database_url }}
+          DATABASE_USERNAME: ${{ needs.resolve-db.outputs.database_username }}
+          DATABASE_PASSWORD_SECRET_NAME: ${{ needs.resolve-db.outputs.database_password_secret_name }}
+          TUNNEL_LOCAL_PORT: ${{ needs.resolve-db.outputs.tunnel_local_port }}
+          TUNNEL_REMOTE_HOST: ${{ needs.resolve-db.outputs.tunnel_remote_host }}
+          TUNNEL_REMOTE_PORT: ${{ needs.resolve-db.outputs.tunnel_remote_port }}
         with:
           script: |
-            const pullNumber = Number(process.env.PR_NUMBER);
-            const body = [
-              "---",
-              "### DB migration succeeded",
-              "",
-              `- Target: ${process.env.TARGET_SUMMARY}`,
-              `- GitHub Environment: ${process.env.ENVIRONMENT_ID}`,
-              "---",
-            ].join("\n");
-
-            await github.rest.pulls.createReview({
+            await github.rest.repos.createDispatchEvent({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: pullNumber,
-              body,
-              event: "COMMENT",
+              event_type: "db-migrate-command",
+              client_payload: {
+                prNumber: Number(process.env.PR_NUMBER),
+                targetSummary: process.env.TARGET_SUMMARY,
+                prHeadRef: process.env.PR_HEAD_REF,
+                checkoutRef: process.env.CHECKOUT_REF,
+                environmentId: process.env.ENVIRONMENT_ID,
+                databaseName: process.env.DATABASE_NAME,
+                databaseUrl: process.env.DATABASE_URL,
+                databaseUsername: process.env.DATABASE_USERNAME,
+                databasePasswordSecretName: process.env.DATABASE_PASSWORD_SECRET_NAME,
+                tunnelLocalPort: process.env.TUNNEL_LOCAL_PORT,
+                tunnelRemoteHost: process.env.TUNNEL_REMOTE_HOST,
+                tunnelRemotePort: process.env.TUNNEL_REMOTE_PORT,
+              },
             });
 
-      - name: Post failure comment
-        if: failure()
-        uses: actions/github-script@v7
-        env:
-          PR_NUMBER: ${{ github.event.issue.number }}
-          TARGET_SUMMARY: ${{ needs.resolve-db.outputs.summary }}
-        with:
-          script: |
-            const pullNumber = Number(process.env.PR_NUMBER);
-            const workflowRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const body = [
-              "---",
-              "### DB migration failed",
-              "",
-              `- Target: ${process.env.TARGET_SUMMARY}`,
-              `- Workflow: ${workflowRunUrl}`,
-              "---",
-            ].join("\n");
-
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullNumber,
-              body,
-              event: "COMMENT",
-            });
-
-  deploy:
+  dispatch-service-deploy:
     needs:
       - prepare
       - resolve-service
     if: needs.resolve-service.outputs.enabled == 'true'
     runs-on: ubuntu-latest
-    environment: ${{ needs.resolve-service.outputs.environment_id }}
     permissions:
-      contents: read
-      packages: write
+      contents: write
       pull-requests: write
-    env:
-      DEPLOY_VM_PORT: ${{ vars.DEPLOY_VM_PORT }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.prepare.outputs.checkout_ref }}
-          fetch-depth: 0
-
-      - name: Post start comment
+      - name: Dispatch service deploy workflow
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
           TARGET_SUMMARY: ${{ needs.resolve-service.outputs.summary }}
           PR_HEAD_REF: ${{ needs.prepare.outputs.pr_head_ref }}
-        with:
-          script: |
-            const pullNumber = Number(process.env.PR_NUMBER);
-            const workflowRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const body = [
-              "---",
-              "### Service deploy started",
-              "",
-              `- Target: ${process.env.TARGET_SUMMARY}`,
-              `- Branch: ${process.env.PR_HEAD_REF}`,
-              `- Workflow: ${workflowRunUrl}`,
-              "---",
-            ].join("\n");
-
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullNumber,
-              body,
-              event: "COMMENT",
-            });
-
-      - name: Execute deployment
-        uses: ./.github/actions/auth-dev-deploy-run
-        with:
-          github_environment: ${{ needs.resolve-service.outputs.environment_id }}
-        env:
-          DEPLOY_VM_PORT: ${{ vars.DEPLOY_VM_PORT }}
-          DEPLOY_VM_HOST: ${{ secrets.DEPLOY_VM_HOST }}
-          DEPLOY_VM_USER: ${{ secrets.DEPLOY_VM_USER }}
-          DEPLOY_VM_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_VM_SSH_PRIVATE_KEY }}
-          GHCR_PULL_USERNAME: ${{ secrets.GHCR_PULL_USERNAME }}
-          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
-          MAVEN_REPOSITORY_USERNAME: ${{ vars.MAVEN_REPOSITORY_USERNAME }}
-          MAVEN_REPOSITORY_TOKEN: ${{ secrets.MAVEN_REPOSITORY_TOKEN }}
-          AUTHS_SOX_DB_PASSWORD: ${{ secrets.AUTHS_SOX_DB_PASSWORD }}
-          AUTH_JWT_PRIVATE_KEY: ${{ secrets.AUTH_JWT_PRIVATE_KEY }}
-          AUTH_JWT_PUBLIC_KEY: ${{ secrets.AUTH_JWT_PUBLIC_KEY }}
-          SECURITY_EMAIL_VERIFICATION_HMAC_SECRET: ${{ secrets.SECURITY_EMAIL_VERIFICATION_HMAC_SECRET }}
-
-      - name: Post success comment
-        if: success()
-        uses: actions/github-script@v7
-        env:
-          PR_NUMBER: ${{ github.event.issue.number }}
-          TARGET_SUMMARY: ${{ needs.resolve-service.outputs.summary }}
+          CHECKOUT_REF: ${{ needs.prepare.outputs.checkout_ref }}
           ENVIRONMENT_ID: ${{ needs.resolve-service.outputs.environment_id }}
         with:
           script: |
-            const pullNumber = Number(process.env.PR_NUMBER);
-            const body = [
-              "---",
-              "### Service deploy succeeded",
-              "",
-              `- Target: ${process.env.TARGET_SUMMARY}`,
-              `- GitHub Environment: ${process.env.ENVIRONMENT_ID}`,
-              "---",
-            ].join("\n");
-
-            await github.rest.pulls.createReview({
+            await github.rest.repos.createDispatchEvent({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: pullNumber,
-              body,
-              event: "COMMENT",
-            });
-
-      - name: Post failure comment
-        if: failure()
-        uses: actions/github-script@v7
-        env:
-          PR_NUMBER: ${{ github.event.issue.number }}
-          TARGET_SUMMARY: ${{ needs.resolve-service.outputs.summary }}
-        with:
-          script: |
-            const pullNumber = Number(process.env.PR_NUMBER);
-            const workflowRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const body = [
-              "---",
-              "### Service deploy failed",
-              "",
-              `- Target: ${process.env.TARGET_SUMMARY}`,
-              `- Workflow: ${workflowRunUrl}`,
-              "---",
-            ].join("\n");
-
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullNumber,
-              body,
-              event: "COMMENT",
+              event_type: "service-deploy-command",
+              client_payload: {
+                prNumber: Number(process.env.PR_NUMBER),
+                targetSummary: process.env.TARGET_SUMMARY,
+                prHeadRef: process.env.PR_HEAD_REF,
+                checkoutRef: process.env.CHECKOUT_REF,
+                environmentId: process.env.ENVIRONMENT_ID,
+              },
             });

--- a/.github/workflows/service-deploy-on-command.yml
+++ b/.github/workflows/service-deploy-on-command.yml
@@ -1,0 +1,122 @@
+name: Service Deploy On Command
+
+on:
+  repository_dispatch:
+    types:
+      - service-deploy-command
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.client_payload.environmentId }}
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+    env:
+      DEPLOY_VM_PORT: ${{ vars.DEPLOY_VM_PORT }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.checkoutRef }}
+          fetch-depth: 0
+
+      - name: Post start comment
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.client_payload.prNumber }}
+          TARGET_SUMMARY: ${{ github.event.client_payload.targetSummary }}
+          PR_HEAD_REF: ${{ github.event.client_payload.prHeadRef }}
+        with:
+          script: |
+            const pullNumber = Number(process.env.PR_NUMBER);
+            const workflowRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = [
+              "---",
+              "### Service deploy started",
+              "",
+              `- Target: ${process.env.TARGET_SUMMARY}`,
+              `- Branch: ${process.env.PR_HEAD_REF}`,
+              `- Workflow: ${workflowRunUrl}`,
+              "---",
+            ].join("\n");
+
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+              body,
+              event: "COMMENT",
+            });
+
+      - name: Execute deployment
+        uses: ./.github/actions/auth-dev-deploy-run
+        with:
+          github_environment: ${{ github.event.client_payload.environmentId }}
+        env:
+          DEPLOY_VM_PORT: ${{ vars.DEPLOY_VM_PORT }}
+          DEPLOY_VM_HOST: ${{ secrets.DEPLOY_VM_HOST }}
+          DEPLOY_VM_USER: ${{ secrets.DEPLOY_VM_USER }}
+          DEPLOY_VM_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_VM_SSH_PRIVATE_KEY }}
+          GHCR_PULL_USERNAME: ${{ secrets.GHCR_PULL_USERNAME }}
+          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
+          MAVEN_REPOSITORY_USERNAME: ${{ vars.MAVEN_REPOSITORY_USERNAME }}
+          MAVEN_REPOSITORY_TOKEN: ${{ secrets.MAVEN_REPOSITORY_TOKEN }}
+          AUTHS_SOX_DB_PASSWORD: ${{ secrets.AUTHS_SOX_DB_PASSWORD }}
+          AUTH_JWT_PRIVATE_KEY: ${{ secrets.AUTH_JWT_PRIVATE_KEY }}
+          AUTH_JWT_PUBLIC_KEY: ${{ secrets.AUTH_JWT_PUBLIC_KEY }}
+          SECURITY_EMAIL_VERIFICATION_HMAC_SECRET: ${{ secrets.SECURITY_EMAIL_VERIFICATION_HMAC_SECRET }}
+
+      - name: Post success comment
+        if: success()
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.client_payload.prNumber }}
+          TARGET_SUMMARY: ${{ github.event.client_payload.targetSummary }}
+          ENVIRONMENT_ID: ${{ github.event.client_payload.environmentId }}
+        with:
+          script: |
+            const pullNumber = Number(process.env.PR_NUMBER);
+            const body = [
+              "---",
+              "### Service deploy succeeded",
+              "",
+              `- Target: ${process.env.TARGET_SUMMARY}`,
+              `- GitHub Environment: ${process.env.ENVIRONMENT_ID}`,
+              "---",
+            ].join("\n");
+
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+              body,
+              event: "COMMENT",
+            });
+
+      - name: Post failure comment
+        if: failure()
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.client_payload.prNumber }}
+          TARGET_SUMMARY: ${{ github.event.client_payload.targetSummary }}
+        with:
+          script: |
+            const pullNumber = Number(process.env.PR_NUMBER);
+            const workflowRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = [
+              "---",
+              "### Service deploy failed",
+              "",
+              `- Target: ${process.env.TARGET_SUMMARY}`,
+              `- Workflow: ${workflowRunUrl}`,
+              "---",
+            ].join("\n");
+
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+              body,
+              event: "COMMENT",
+            });

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.sitionix.forge</groupId>
             <artifactId>forge-security-server</artifactId>
             <version>${forge.security.version}</version>

--- a/boot/src/main/java/com/sitionix/athssox/config/SecurityConfig.java
+++ b/boot/src/main/java/com/sitionix/athssox/config/SecurityConfig.java
@@ -21,7 +21,10 @@ public class SecurityConfig {
 
     private static final String[] PUBLIC_ENDPOINTS = {
             "/.well-known/jwks.json",
-            "/oauth2/v1/keys"
+            "/oauth2/v1/keys",
+            "/actuator/health",
+            "/actuator/health/readiness",
+            "/actuator/health/liveness"
     };
 
     @Bean

--- a/boot/src/main/resources/application.yml
+++ b/boot/src/main/resources/application.yml
@@ -14,6 +14,21 @@ spring:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: validate
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: never
+  endpoints:
+    web:
+      exposure:
+        include: "health,info"
+  health:
+    livenessstate:
+      enabled: true
+    readinessstate:
+      enabled: true
 auth:
   tokens:
     issuer: athssox
@@ -60,3 +75,6 @@ forge:
       excludes:
         - "/.well-known/jwks.json"
         - "/oauth2/v1/keys"
+        - "/actuator/health"
+        - "/actuator/health/readiness"
+        - "/actuator/health/liveness"

--- a/deploy/auth/ci/verify-private-deploy.sh
+++ b/deploy/auth/ci/verify-private-deploy.sh
@@ -10,6 +10,38 @@ require_env() {
   fi
 }
 
+wait_for_up_status() {
+  local url="$1"
+  local label="$2"
+  local response_file
+  response_file="$(mktemp)"
+
+  for _ in $(seq 1 20); do
+    if curl -sS -o "${response_file}" -w '%{http_code}' "${url}" | grep -qx '200'; then
+      if python3 - "${response_file}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+if payload.get("status") != "UP":
+    raise SystemExit(1)
+PY
+      then
+        rm -f "${response_file}"
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+
+  echo "${label} did not become UP at ${url}" >&2
+  cat "${response_file}" >&2 || true
+  rm -f "${response_file}"
+  exit 1
+}
+
 for variable_name in \
   DEPLOY_VM_HOST \
   DEPLOY_VM_USER \
@@ -65,6 +97,11 @@ fi
 
 canonical_url="http://127.0.0.1:${local_port}/authsox/.well-known/jwks.json"
 alias_url="http://127.0.0.1:${local_port}/authsox/oauth2/v1/keys"
+readiness_url="http://127.0.0.1:${local_port}/authsox/actuator/health/readiness"
+health_url="http://127.0.0.1:${local_port}/authsox/actuator/health"
+
+wait_for_up_status "${readiness_url}" "Auth private readiness"
+wait_for_up_status "${health_url}" "Auth private health"
 
 curl -fsS "${canonical_url}" > "${canonical_file}"
 curl -fsS "${alias_url}" > "${alias_file}"

--- a/deploy/auth/vm/deploy-auth.sh
+++ b/deploy/auth/vm/deploy-auth.sh
@@ -68,6 +68,8 @@ for variable_name in \
   SITIONIX_KEYS_DIR \
   SITIONIX_JWT_PRIVATE_KEY_PATH \
   SITIONIX_JWT_PUBLIC_KEY_PATH \
+  SITIONIX_LOCAL_READINESS_URL \
+  SITIONIX_LOCAL_HEALTH_URL \
   SITIONIX_LOCAL_JWKS_URL \
   SITIONIX_DB_URL \
   SITIONIX_DB_USERNAME \
@@ -148,7 +150,13 @@ if ! docker run -d \
   exit 1
 fi
 
-if ! wait_for_url "${SITIONIX_LOCAL_JWKS_URL}" 30; then
+if ! wait_for_url "${SITIONIX_LOCAL_READINESS_URL}" 30; then
+  docker logs "${SITIONIX_CONTAINER_NAME}" --tail 200 >&2 || true
+  rollback_previous_container
+  exit 1
+fi
+
+if ! wait_for_url "${SITIONIX_LOCAL_HEALTH_URL}" 10; then
   docker logs "${SITIONIX_CONTAINER_NAME}" --tail 200 >&2 || true
   rollback_previous_container
   exit 1

--- a/docs/dev-vm-deploy.md
+++ b/docs/dev-vm-deploy.md
@@ -2,10 +2,13 @@
 
 ## Model
 - Push to `develop` triggers `Dev Deploy On Push`.
-- A pull request comment can trigger `Deploy On Comment` against the PR head branch:
+- A pull request comment can trigger the lightweight `Deploy Comment Router`, which dispatches one real command workflow against the PR head branch:
   ```text
   /deploy service --name authorisationservice-sox --env dev
   ```
+- Real command workflows are split:
+  - `Service Deploy On Command`
+  - `DB Migrate On Command`
 - GitHub Actions builds and publishes the runtime image, uploads a release bundle to the VM, and performs the rollout over SSH.
 - The VM is runtime-only. The workflow does not use `git pull` and does not require manual VM edits.
 - The shared PR comment workflow routes only one target per command:
@@ -41,7 +44,9 @@ Use GitHub Environment `dev`.
 - Docker network alias: `authorisationservice-sox`
 - Host-only bind: `127.0.0.1:9090 -> 9090`
 - Internal base URL for downstream services: `http://authorisationservice-sox:9090/authsox`
-- VM-local verification URL: `http://127.0.0.1:9090/authsox/.well-known/jwks.json`
+- VM-local readiness URL: `http://127.0.0.1:9090/authsox/actuator/health/readiness`
+- VM-local health URL: `http://127.0.0.1:9090/authsox/actuator/health`
+- VM-local JWKS URL: `http://127.0.0.1:9090/authsox/.well-known/jwks.json`
 
 ## Files Materialized on the VM
 - Runtime root: `/opt/sitionix/runtime/authorisationservice-sox`
@@ -69,9 +74,12 @@ The deploy workflow materializes these runtime values for the container:
 - JWT key id falls back to the application default `local-dev`
 
 ## Verification
-- Remote rollout waits for the private JWKS endpoint:
-  - `GET /authsox/.well-known/jwks.json`
+- Remote rollout waits for Spring actuator health:
+  - `GET /authsox/actuator/health/readiness`
+  - `GET /authsox/actuator/health`
 - Workflow smoke verification opens an SSH tunnel to `127.0.0.1:9090` on the VM and checks:
+  - readiness endpoint returns `UP`
+  - health endpoint returns `UP`
   - canonical JWKS endpoint
   - alias JWKS endpoint
   - both responses are identical


### PR DESCRIPTION
## Summary
- split auth comment routing from real DB/service execution workflows
- add actuator health/readiness for auth deploy verification
- keep JWKS smoke as the final private verification

## Verification
- ruby YAML load for workflows and actions
- bash -n for auth deploy scripts
- mvn -q -f pom.xml -pl boot -am -DskipTests package