### PR TITLE
[SITIONIX-101] - fix auth db dispatch and deploy migration hook

### DIFF
--- a/.github/workflows/auth-dev-deploy-on-push.yml
+++ b/.github/workflows/auth-dev-deploy-on-push.yml
@@ -7,7 +7,9 @@ on:
     paths:
       - ".github/workflows/auth-dev-deploy-on-push.yml"
       - ".github/actions/auth-dev-deploy-run/**"
+      - ".github/actions/db-migrate-run/**"
       - ".github/actions/materialize-maven-settings/**"
+      - "db-migration/**"
       - "deploy/auth/**"
       - "boot/**"
       - "api-rest/**"
@@ -24,7 +26,103 @@ permissions:
   packages: write
 
 jobs:
+  detect-db-migrations:
+    runs-on: ubuntu-latest
+    outputs:
+      migrations_changed: ${{ steps.detect.outputs.migrations_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Detect DB migration changes
+        id: detect
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ "${EVENT_NAME}" != "push" || -z "${BEFORE_SHA}" || "${BEFORE_SHA}" == "0000000000000000000000000000000000000000" ]]; then
+            echo "migrations_changed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if git diff --name-only "${BEFORE_SHA}" "${AFTER_SHA}" | grep -Eq '^db-migration/'; then
+            echo "migrations_changed=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "migrations_changed=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+  db-migrate:
+    needs: detect-db-migrations
+    if: needs.detect-db-migrations.outputs.migrations_changed == 'true'
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      contents: read
+    outputs:
+      database_name: ${{ steps.resolve.outputs.database_name }}
+      database_url: ${{ steps.resolve.outputs.database_url }}
+      database_username: ${{ steps.resolve.outputs.database_username }}
+      database_password_secret_name: ${{ steps.resolve.outputs.database_password_secret_name }}
+      tunnel_local_port: ${{ steps.resolve.outputs.tunnel_local_port }}
+      tunnel_remote_host: ${{ steps.resolve.outputs.tunnel_remote_host }}
+      tunnel_remote_port: ${{ steps.resolve.outputs.tunnel_remote_port }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Resolve DB migration target
+        id: resolve
+        shell: bash
+        run: |
+          ruby - <<'INNER_RUBY'
+          require "yaml"
+          model = YAML.load_file("db-migration/db-model.yaml")
+          env = model.fetch("database").fetch("environments").fetch("dev")
+          tunnel = env.fetch("tunnel")
+
+          File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |out|
+            out.puts("database_name=#{model.fetch("database").fetch("name")}")
+            out.puts("database_url=#{env.fetch("url")}")
+            out.puts("database_username=#{env.fetch("username")}")
+            out.puts("database_password_secret_name=#{env.fetch("password_secret_name")}")
+            out.puts("tunnel_local_port=#{tunnel.fetch("local_port")}")
+            out.puts("tunnel_remote_host=#{tunnel.fetch("remote_host")}")
+            out.puts("tunnel_remote_port=#{tunnel.fetch("remote_port")}")
+          end
+          INNER_RUBY
+
+      - name: Execute DB migration
+        uses: ./.github/actions/db-migrate-run
+        with:
+          environment_id: dev
+          database_name: ${{ steps.resolve.outputs.database_name }}
+        env:
+          FLYWAY_URL: ${{ steps.resolve.outputs.database_url }}
+          FLYWAY_USERNAME: ${{ steps.resolve.outputs.database_username }}
+          FLYWAY_PASSWORD: ${{ secrets[steps.resolve.outputs.database_password_secret_name] }}
+          DEPLOY_VM_HOST: ${{ secrets.DEPLOY_VM_HOST }}
+          DEPLOY_VM_USER: ${{ secrets.DEPLOY_VM_USER }}
+          DEPLOY_VM_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_VM_SSH_PRIVATE_KEY }}
+          SSH_TUNNEL_LOCAL_PORT: ${{ steps.resolve.outputs.tunnel_local_port }}
+          SSH_TUNNEL_REMOTE_HOST: ${{ steps.resolve.outputs.tunnel_remote_host }}
+          SSH_TUNNEL_REMOTE_PORT: ${{ steps.resolve.outputs.tunnel_remote_port }}
+
   deploy:
+    needs:
+      - detect-db-migrations
+      - db-migrate
+    if: |
+      always() &&
+      needs.detect-db-migrations.result == 'success' &&
+      (
+        needs.detect-db-migrations.outputs.migrations_changed != 'true' ||
+        needs.db-migrate.result == 'success'
+      )
     runs-on: ubuntu-latest
     environment: dev
     env:

--- a/.github/workflows/db-migrate-on-command.yml
+++ b/.github/workflows/db-migrate-on-command.yml
@@ -50,17 +50,17 @@ jobs:
         uses: ./.github/actions/db-migrate-run
         with:
           environment_id: ${{ github.event.client_payload.environmentId }}
-          database_name: ${{ github.event.client_payload.databaseName }}
+          database_name: ${{ github.event.client_payload.database.name }}
         env:
-          FLYWAY_URL: ${{ github.event.client_payload.databaseUrl }}
-          FLYWAY_USERNAME: ${{ github.event.client_payload.databaseUsername }}
-          FLYWAY_PASSWORD: ${{ secrets[github.event.client_payload.databasePasswordSecretName] }}
+          FLYWAY_URL: ${{ github.event.client_payload.database.url }}
+          FLYWAY_USERNAME: ${{ github.event.client_payload.database.username }}
+          FLYWAY_PASSWORD: ${{ secrets[github.event.client_payload.database.passwordSecretName] }}
           DEPLOY_VM_HOST: ${{ secrets.DEPLOY_VM_HOST }}
           DEPLOY_VM_USER: ${{ secrets.DEPLOY_VM_USER }}
           DEPLOY_VM_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_VM_SSH_PRIVATE_KEY }}
-          SSH_TUNNEL_LOCAL_PORT: ${{ github.event.client_payload.tunnelLocalPort }}
-          SSH_TUNNEL_REMOTE_HOST: ${{ github.event.client_payload.tunnelRemoteHost }}
-          SSH_TUNNEL_REMOTE_PORT: ${{ github.event.client_payload.tunnelRemotePort }}
+          SSH_TUNNEL_LOCAL_PORT: ${{ github.event.client_payload.tunnel.localPort }}
+          SSH_TUNNEL_REMOTE_HOST: ${{ github.event.client_payload.tunnel.remoteHost }}
+          SSH_TUNNEL_REMOTE_PORT: ${{ github.event.client_payload.tunnel.remotePort }}
 
       - name: Post success comment
         if: success()

--- a/.github/workflows/deploy-on-comment.yml
+++ b/.github/workflows/deploy-on-comment.yml
@@ -195,13 +195,17 @@ jobs:
                 prHeadRef: process.env.PR_HEAD_REF,
                 checkoutRef: process.env.CHECKOUT_REF,
                 environmentId: process.env.ENVIRONMENT_ID,
-                databaseName: process.env.DATABASE_NAME,
-                databaseUrl: process.env.DATABASE_URL,
-                databaseUsername: process.env.DATABASE_USERNAME,
-                databasePasswordSecretName: process.env.DATABASE_PASSWORD_SECRET_NAME,
-                tunnelLocalPort: process.env.TUNNEL_LOCAL_PORT,
-                tunnelRemoteHost: process.env.TUNNEL_REMOTE_HOST,
-                tunnelRemotePort: process.env.TUNNEL_REMOTE_PORT,
+                database: {
+                  name: process.env.DATABASE_NAME,
+                  url: process.env.DATABASE_URL,
+                  username: process.env.DATABASE_USERNAME,
+                  passwordSecretName: process.env.DATABASE_PASSWORD_SECRET_NAME,
+                },
+                tunnel: {
+                  localPort: process.env.TUNNEL_LOCAL_PORT,
+                  remoteHost: process.env.TUNNEL_REMOTE_HOST,
+                  remotePort: process.env.TUNNEL_REMOTE_PORT,
+                },
               },
             });
 


### PR DESCRIPTION
## Summary
- compact DB repository_dispatch payload to satisfy GitHub limits
- auto-run DB migrations on push deploy when files under `db-migration/` change
- keep service deploy blocked until migration succeeds when migrations changed

## Verification
- workflow YAML parsed locally
