### PR TITLE
[SITIONIX-101] - bump auth forgeit version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <jacoco.version>0.8.10</jacoco.version>
         <validation.version>2.0.1.Final</validation.version>
         <spring.version>3.3.4</spring.version>
-        <forgeit.version>0.0.35</forgeit.version>
+        <forgeit.version>0.0.39</forgeit.version>
         <forge.security.version>0.0.4</forge.security.version>
         <forge.common.version>0.0.8</forge.common.version>
     </properties>


### PR DESCRIPTION
Summary:
- bump forgeit.version to 0.0.39
- keep the PR scoped only to the auth dependency update
- verified with mvn clean install
