### PR TITLE
[SITIONIX-107] - mount auth keys dir in deploy container run

### DIFF
--- a/.github/deploy/auth/vm/deploy-auth.sh
+++ b/.github/deploy/auth/vm/deploy-auth.sh
@@ -143,6 +143,7 @@ if ! docker run -d \
   --network "${SITIONIX_DOCKER_NETWORK}" \
   --network-alias "${SITIONIX_NETWORK_ALIAS}" \
   -p "${SITIONIX_BIND_ADDRESS}:${SITIONIX_HOST_PORT}:${SITIONIX_CONTAINER_PORT}" \
+  -v "${SITIONIX_KEYS_DIR}:${SITIONIX_KEYS_DIR}:ro" \
   --env-file "${SITIONIX_SHARED_SECRET_ENV_PATH}" \
   --env-file "${SITIONIX_SERVICE_ENV_PATH}" \
   "${SITIONIX_IMAGE_REF}" >/dev/null; then


### PR DESCRIPTION
## Summary
- keep existing auth deploy/secrets flow as-is
- mount `${SITIONIX_KEYS_DIR}` into container during `docker run`
- ensure `AUTH_JWT_*_PATH` points to a file path visible inside container

## Why
Auth deploy failed with `JWT key resource not found` even though key was present on VM host, because the host keys path was not mounted into the container.

## Scope
- `.github/deploy/auth/vm/deploy-auth.sh` only
