### PR TITLE
[codex] Honor DEPLOY_VM_PORT for SSH workflows

### DIFF
--- a/.github/actions/db-migrate-run/action.yml
+++ b/.github/actions/db-migrate-run/action.yml
@@ -83,12 +83,14 @@ runs:
         trap cleanup EXIT
 
         if [[ -n "${SSH_TUNNEL_LOCAL_PORT:-}" ]]; then
+          DEPLOY_VM_PORT="${DEPLOY_VM_PORT:-22}"
           mkdir -p ~/.ssh
           printf '%s\n' "${DEPLOY_VM_SSH_PRIVATE_KEY}" > "${key_path}"
           chmod 600 "${key_path}"
 
           ssh \
             -i "${key_path}" \
+            -p "${DEPLOY_VM_PORT}" \
             -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=accept-new \
             -o ExitOnForwardFailure=yes \

--- a/.github/workflows/auth-dev-deploy-on-push.yml
+++ b/.github/workflows/auth-dev-deploy-on-push.yml
@@ -106,6 +106,7 @@ jobs:
           FLYWAY_PASSWORD: ${{ secrets[steps.resolve.outputs.database_password_secret_name] }}
           DEPLOY_VM_HOST: ${{ secrets.DEPLOY_VM_HOST }}
           DEPLOY_VM_USER: ${{ secrets.DEPLOY_VM_USER }}
+          DEPLOY_VM_PORT: ${{ vars.DEPLOY_VM_PORT }}
           DEPLOY_VM_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_VM_SSH_PRIVATE_KEY }}
           SSH_TUNNEL_LOCAL_PORT: ${{ steps.resolve.outputs.tunnel_local_port }}
           SSH_TUNNEL_REMOTE_HOST: ${{ steps.resolve.outputs.tunnel_remote_host }}

--- a/.github/workflows/db-migrate-on-command.yml
+++ b/.github/workflows/db-migrate-on-command.yml
@@ -57,6 +57,7 @@ jobs:
           FLYWAY_PASSWORD: ${{ secrets[github.event.client_payload.database.passwordSecretName] }}
           DEPLOY_VM_HOST: ${{ secrets.DEPLOY_VM_HOST }}
           DEPLOY_VM_USER: ${{ secrets.DEPLOY_VM_USER }}
+          DEPLOY_VM_PORT: ${{ vars.DEPLOY_VM_PORT }}
           DEPLOY_VM_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_VM_SSH_PRIVATE_KEY }}
           SSH_TUNNEL_LOCAL_PORT: ${{ github.event.client_payload.tunnel.localPort }}
           SSH_TUNNEL_REMOTE_HOST: ${{ github.event.client_payload.tunnel.remoteHost }}


### PR DESCRIPTION
## Summary

- Pass `DEPLOY_VM_PORT` from the `dev` GitHub Environment into DB migration workflows.
- Use `ssh -p "${DEPLOY_VM_PORT:-22}"` for migration tunnels.
- Verified deploy SSH/SCP usages honor the configured port.

## Why

The local Ubuntu dev VM is reachable externally on port `22222`, while SSH inside the LAN remains port `22`. Workflows must use the GitHub Environment variable instead of relying on SSH default port `22`.

## Validation

- `bash -n` on changed scripts where applicable.
- Grep audit of SSH/SCP/keyscan usage.
- No migrations or deployments were run.