### PR TITLE
[codex] Mount auth JWT keys in dev container

### DIFF
--- a/.github/deploy/auth/vm/deploy-auth.sh
+++ b/.github/deploy/auth/vm/deploy-auth.sh
@@ -121,6 +121,20 @@ chmod 0600 "${SITIONIX_JWT_PRIVATE_KEY_PATH}" "${SITIONIX_JWT_PUBLIC_KEY_PATH}"
 } > "${SITIONIX_SERVICE_ENV_PATH}"
 chmod 0600 "${SITIONIX_SERVICE_ENV_PATH}"
 
+if ! docker run --rm \
+  --entrypoint sh \
+  --env-file "${SITIONIX_SHARED_SECRET_ENV_PATH}" \
+  --env-file "${SITIONIX_SERVICE_ENV_PATH}" \
+  --mount "type=bind,src=${SITIONIX_KEYS_DIR},dst=${SITIONIX_KEYS_DIR},readonly" \
+  "${SITIONIX_IMAGE_REF}" \
+  -lc '
+    test -r "${AUTH_JWT_PRIVATE_KEY_PATH:?}"
+    test -r "${AUTH_JWT_PUBLIC_KEY_PATH:?}"
+  '; then
+  echo "JWT key files are not readable from the container runtime." >&2
+  exit 1
+fi
+
 if ! docker network inspect "${SITIONIX_DOCKER_NETWORK}" >/dev/null 2>&1; then
   docker network create "${SITIONIX_DOCKER_NETWORK}" >/dev/null
 fi
@@ -145,6 +159,7 @@ if ! docker run -d \
   -p "${SITIONIX_BIND_ADDRESS}:${SITIONIX_HOST_PORT}:${SITIONIX_CONTAINER_PORT}" \
   --env-file "${SITIONIX_SHARED_SECRET_ENV_PATH}" \
   --env-file "${SITIONIX_SERVICE_ENV_PATH}" \
+  --mount "type=bind,src=${SITIONIX_KEYS_DIR},dst=${SITIONIX_KEYS_DIR},readonly" \
   "${SITIONIX_IMAGE_REF}" >/dev/null; then
   rollback_previous_container
   exit 1

--- a/docs/dev-vm-deploy.md
+++ b/docs/dev-vm-deploy.md
@@ -55,6 +55,8 @@ Use GitHub Environment `dev`.
 - JWT key files:
   - `/opt/sitionix/runtime/authorisationservice-sox/shared/keys/jwt-private.pem`
   - `/opt/sitionix/runtime/authorisationservice-sox/shared/keys/jwt-public.pem`
+- JWT key directory bind mount:
+  - `/opt/sitionix/runtime/authorisationservice-sox/shared/keys` is mounted into the container at the same absolute path as read-only.
 - Shared internal auth env file, owned by infra:
   - `/opt/sitionix/runtime/shared/dev-internal-auth.env`
 - Release backups:
@@ -77,6 +79,7 @@ The deploy workflow materializes these runtime values for the container:
 - Remote rollout waits for Spring actuator health:
   - `GET /authsox/actuator/health/readiness`
   - `GET /authsox/actuator/health`
+- Before replacing the running container, rollout starts a temporary container with the same image, env files, and read-only key mount to verify that both configured JWT key paths are readable.
 - Workflow smoke verification opens an SSH tunnel to `127.0.0.1:9090` on the VM and checks:
   - readiness endpoint returns `UP`
   - health endpoint returns `UP`


### PR DESCRIPTION
## Summary

- Mount the auth JWT key directory into the dev VM container as read-only.
- Preserve the existing JWT key absolute paths passed through env.
- Add a pre-health runtime check that verifies the container can read both JWT key files before actuator polling.

## Why

RCA showed that the VM deploy writes JWT key files to the host and passes those host paths to the container, but the container starts with no bind mounts. The app then fails during Spring startup because the configured key path does not exist inside the container.

## Validation

- `bash -n .github/deploy/auth/vm/deploy-auth.sh`
- `bash -n .github/deploy/auth/ci/verify-private-deploy.sh`
- Grep audit for key paths and Docker mount usage.
- No DB migrations or unrelated service deployments were run.